### PR TITLE
Remove step to delete file to be overridden

### DIFF
--- a/chrome-overrider.sh
+++ b/chrome-overrider.sh
@@ -15,9 +15,6 @@ fi
 
 if   [[ -d $OVERRIDE_DIR ]]
   then
-    echo "--- Clearing old override"
-    rm "$OVERRIDE_DIR"/"$OVERRIDE_FILE"
-
     echo "--- Building new override"
     npm run build
 


### PR DESCRIPTION
Fixes #3 

Instead of deleting the file to be overridden, then copying the new file to it's location. Rely on `cp` to override any existing file with the same name